### PR TITLE
Add support for supplying path through CLI, and converting timezones

### DIFF
--- a/git-punchcard
+++ b/git-punchcard
@@ -8,6 +8,7 @@ import cairo
 import sys
 import subprocess
 import os
+from email.utils import mktime_tz, parsedate_tz, formatdate
 
 # defaults
 author = ''
@@ -33,6 +34,7 @@ if len(sys.argv) > 1:
 original_path = os.getcwd()
 path = os.getcwd()
 opaque = -1
+utc = 0
 
 options = dict()
 
@@ -53,6 +55,8 @@ if options.has_key('opaque'):
         print("WARNING: Could not parse the opaque argument you gave. Please \
         enter a value between 0 and 1")
         opaque = -1
+if options.has_key('utc'):
+    utc = options['utc'] == '1'
 
 height = int(round(width/2.75, 0))
 
@@ -99,6 +103,14 @@ def get_log_data():
 
 # get day and hour
 temp_log = get_log_data()
+
+# CONVERT EVERYTHING TO UTC
+if utc:
+    all_time_stamps = temp_log.split('\n')
+    times_in_utc = [formatdate(mktime_tz(parsedate_tz(x))) for x in temp_log.split('\n')]
+
+    temp_log = '\n'.join(times_in_utc)
+
 data_log = [[x.strip().split(',')[0], x.strip().split(' ')[4].split(':')[0]] for x in temp_log.split('\n')]
 
 stats = {}

--- a/git-punchcard
+++ b/git-punchcard
@@ -29,12 +29,18 @@ if len(sys.argv) > 1:
         print("This sets the opacity of all the circles to constant value 0")
         print("0 -> Black, 1 -> White (invisible)")
         print
+        print("EXAMPLE:   git punchcard timezone=+7.5")
+        print("This shows the graph with all times converted to timezone UTC+7.5")
+        print("If your contributors live in multiple timezones, this helps you")
+        print("in getting a relative estimate of when they work.")
+        print
         sys.exit(0)
 
 original_path = os.getcwd()
 path = os.getcwd()
 opaque = -1
 utc = 0
+timezone = None
 
 options = dict()
 
@@ -57,6 +63,14 @@ if options.has_key('opaque'):
         opaque = -1
 if options.has_key('utc'):
     utc = options['utc'] == '1'
+    timezone = 0
+if options.has_key('timezone'):
+    try:
+        timezone = float(options["timezone"])
+    except ValueError as error:
+        print("WARNING: COULD not parse timezone argument.")
+        print("Please enter a decimal value. Eg: 3.0, -11.5")
+        timezone = None
 
 height = int(round(width/2.75, 0))
 
@@ -104,14 +118,18 @@ def get_log_data():
 # get day and hour
 temp_log = get_log_data()
 
-# CONVERT EVERYTHING TO UTC
-if utc:
-    all_time_stamps = temp_log.split('\n')
-    times_in_utc = [formatdate(mktime_tz(parsedate_tz(x))) for x in temp_log.split('\n')]
+# CONVERT EVERYTHING TO UTC or ADD TIMEZONE OFFSET
 
-    temp_log = '\n'.join(times_in_utc)
+utc_offset = timezone != None and timezone * 3600 or 0
 
-data_log = [[x.strip().split(',')[0], x.strip().split(' ')[4].split(':')[0]] for x in temp_log.split('\n')]
+fixed_stamps = temp_log.split('\n')
+
+if timezone != None:
+    fixed_stamps = [formatdate(mktime_tz(parsedate_tz(x)) + utc_offset) \
+            for x in fixed_stamps]
+
+data_log = [[x.strip().split(',')[0], x.strip().split(' ')[4].split(':')[0]] \
+        for x in fixed_stamps]
 
 stats = {}
 for d in days:

--- a/git-punchcard
+++ b/git-punchcard
@@ -7,6 +7,7 @@ import math
 import cairo
 import sys
 import subprocess
+import os
 
 # defaults
 author = ''
@@ -18,10 +19,15 @@ if len(sys.argv) > 1:
         print("SYNTAX:    git punchchard")
         print("EXAMPLE:   git punchchard file=outputfile.png width=4000")
         print("This creates 'outputfile.png', a 4000px wide png image")
+        print("EXAMPLE:   git punchcard path=/home/siddharth/code/punchcard")
+        print("This creates a punch card of the git repository at the given path")
         print()
         sys.exit(0)
 
-options =dict()
+original_path = os.getcwd()
+path = os.getcwd()
+
+options = dict()
 
 if len(sys.argv) > 1:
     options = dict(arg.split('=') for arg in sys.argv[1:])
@@ -31,6 +37,8 @@ if options.has_key('author'):
     author = options['author']
 if options.has_key('file'):
     output_file = options["file"]
+if options.has_key('path'):
+    path = options["path"]
 
 height = int(round(width/2.75, 0))
 
@@ -57,6 +65,7 @@ def get_x_y_from_date(day, hour):
 
 def get_log_data():
     try:
+        os.chdir(path)
         gitcommand = ['git', 'log', '--no-merges', '--author='+author,  '--pretty=format: %aD']
         # if author != None:
         #     gitcommand.append('--author='+author)
@@ -179,7 +188,6 @@ def draw_circle(pos, length):
 for each in final_data:
     draw_circle(each[1], each[0])
 
-
-
 # write to output
+os.chdir(original_path)
 surface.write_to_png (output_file)

--- a/git-punchcard
+++ b/git-punchcard
@@ -41,11 +41,12 @@ path = os.getcwd()
 opaque = -1
 utc = 0
 timezone = None
+gitopts = ""
 
 options = dict()
 
 if len(sys.argv) > 1:
-    options = dict(arg.split('=') for arg in sys.argv[1:])
+    options = dict(arg.split('=', 1) for arg in sys.argv[1:])
 if options.has_key('width'):
     width = int(options['width'])
 if options.has_key('author'):
@@ -71,6 +72,9 @@ if options.has_key('timezone'):
         print("WARNING: COULD not parse timezone argument.")
         print("Please enter a decimal value. Eg: 3.0, -11.5")
         timezone = None
+
+if options.has_key('gitopts'):
+    gitopts = options['gitopts']
 
 height = int(round(width/2.75, 0))
 
@@ -98,10 +102,15 @@ def get_x_y_from_date(day, hour):
 def get_log_data():
     try:
         os.chdir(path)
-        gitcommand = ['git', 'log', '--no-merges', '--author='+author,  '--pretty=format: %aD']
-        # if author != None:
-        #     gitcommand.append('--author='+author)
-        #print(gitcommand)
+        print 'current path: ', os.getcwd()
+        gitcommand = ['git', 'log', '--no-merges', '--author='+author, \
+                '--pretty=format: %aD']
+
+        if gitopts != "":
+            gitcommand.append(gitopts)
+
+        print 'run cmd: ', ' '.join(gitcommand)
+
         p = subprocess.Popen(gitcommand,
                              stdin=subprocess.PIPE,
                              stdout=subprocess.PIPE,
@@ -237,3 +246,5 @@ for each in final_data:
 # write to output
 os.chdir(original_path)
 surface.write_to_png (output_file)
+
+print "punchcard written to output file at: %s" % os.path.join(original_path, output_file)

--- a/git-punchcard
+++ b/git-punchcard
@@ -17,15 +17,22 @@ output_file = 'output.png'
 if len(sys.argv) > 1:
     if sys.argv[1] == "--help" or sys.argv[1] == "-h":
         print("SYNTAX:    git punchchard")
+        print
         print("EXAMPLE:   git punchchard file=outputfile.png width=4000")
         print("This creates 'outputfile.png', a 4000px wide png image")
+        print
         print("EXAMPLE:   git punchcard path=/home/siddharth/code/punchcard")
         print("This creates a punch card of the git repository at the given path")
-        print()
+        print
+        print("EXAMPLE:   git punchcard opaque=0")
+        print("This sets the opacity of all the circles to constant value 0")
+        print("0 -> Black, 1 -> White (invisible)")
+        print
         sys.exit(0)
 
 original_path = os.getcwd()
 path = os.getcwd()
+opaque = -1
 
 options = dict()
 
@@ -39,6 +46,13 @@ if options.has_key('file'):
     output_file = options["file"]
 if options.has_key('path'):
     path = options["path"]
+if options.has_key('opaque'):
+    try:
+        opaque = float(options["opaque"])
+    except ValueError as error:
+        print("WARNING: Could not parse the opaque argument you gave. Please \
+        enter a value between 0 and 1")
+        opaque = -1
 
 height = int(round(width/2.75, 0))
 
@@ -180,6 +194,8 @@ def draw_circle(pos, length):
     # max of length is half of the distance
     x, y = pos
     clr = (1 - float(length * length) / max_range )
+    if opaque >= 0 and opaque < 1:
+        clr = opaque
     cr.set_source_rgba (clr, clr, clr)
     cr.move_to(x, y)
     cr.arc(x, y, length, 0, 2 * math.pi)

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,65 @@
+##### TEST FILE
+
+### Running this file will generate some graphs for this repository
+
+## basic
+
+echo
+echo "BASIC: Invoking without any arguments"
+./git-punchcard file=basic.png
+echo
+
+## opaque
+
+echo
+echo "OPAQUE: Invoking with opaque=0 so that all circles are completely black"
+./git-punchcard opaque=0 file=opaque.png
+echo
+
+## utc
+
+echo
+echo "UTC: Invoking with utc=1"
+echo "All timestamps are converted to UTC before plotting the punchcard"
+./git-punchcard utc=1 opaque=0 file=utc.png
+echo
+
+## custom timezone: positive
+
+echo
+echo "TIMEZONE: Invoking with timezone=7.5"
+echo "All timestamps are converted to UTC+7.5 before plotting the punchcard"
+./git-punchcard timezone=7.5 opaque=0 file=custom-tz-positive.png
+echo
+
+## custom timezone: negative
+
+echo
+echo "TIMEZONE: Invoking with timezone=-7.5"
+echo "All timestamps are converted to UTC-7.5 before plotting the punchcard"
+./git-punchcard timezone=-7.5 opaque=0 file=custom-tz-negative.png
+echo
+
+## git options: test 1: --since option
+
+echo
+echo "GIT OPTIONS: Invoking with --gitopts=\"--since='1 month ago'\""
+echo "All timestamps are converted to UTC+7.5 before plotting the punchcard"
+./git-punchcard gitopts='--since="1 month ago"' opaque=0 file=git-options-since.png
+echo
+
+## git options: test 2: --before option
+
+echo
+echo "GIT OPTIONS: Invoking with --gitopts=\"--before='january 2014'\""
+echo "All timestamps are converted to UTC+7.5 before plotting the punchcard"
+./git-punchcard gitopts='--before="january 2014"' opaque=0 file=git-options-before.png
+echo
+
+## git options: test 3: --since and before option
+
+echo
+echo "GIT OPTIONS: Invoking with --gitopts=\"--before='september 2017' --after='january 2017'\""
+echo "All timestamps are converted to UTC+7.5 before plotting the punchcard"
+./git-punchcard gitopts='--since="1 month ago" --after="january 2017"' opaque=0 file=git-options-period.png
+echo


### PR DESCRIPTION
I came across this while trying to find a good punch card plot generator for repositories that are not there on GitHub!

I have implemented the following features in this PR:

* Add an option to supply path to the script instead of having to put this script in the `PATH`. This enables simply cloning this repository and generating punch cards.

* Add an option to support opaque charts (i.e. no opacity in the circles. all circles are completely black. This I think really helps visibility) Turned on with `opaque=0` Plots with this option turned on look like this:

`$ ./git-punchcard opaque=0`

![image](https://user-images.githubusercontent.com/3668034/27446707-2f4a2dea-579c-11e7-9188-c91ea219d7bc.png)

* Add an option to convert the times to any timezone before plotting the graph. This is especially useful when working with collaborators in different countries and you want to get an estimate on when they are working, relative to your timings and find a suitable window. This implements the request in #5. (Thanks, @codekiln :smile: )

This repository has contributors from -7, -6, +2, +3, and +8. The standard plot looks like this: (with opaque)

`$ ./git-punchcard opaque=0`
![image](https://user-images.githubusercontent.com/3668034/27446707-2f4a2dea-579c-11e7-9188-c91ea219d7bc.png)

To a contributor in UTC+2, this looks like this:

`$ ./git-punchcard opaque=0 timezone=2`
![image](https://user-images.githubusercontent.com/3668034/27446911-b4123900-579c-11e7-9dee-cff8e0cc26c5.png)

Of course, this supports negative offsets also.
